### PR TITLE
feat: publish Capsule Source Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ hosted 環境からのインストールでは、Git release や CI artifact の
 OpenTofuはこのTakosumi管理経路でPlan・Apply・StateVersion・Output・Auditを扱うためのものです。
 Cloudflareへ直接デプロイするだけならOpenTofuは必要ありません。
 
+[`install-options.json`](install-options.json) は、現在実行可能な Cloudflare OpenTofu module を選ぶための任意の
+`CapsuleSourceOptions` 表示ドキュメントです。Takosumi 専用 manifest ではなく、通常の Git URL + module path での
+直接インストールには不要です。この文書は、それを含む次の通常の安定版タグから利用できます。別クラウドの選択肢は、
+対応する実在 module を出荷したときだけ追加します。
+
 ## ブラウザ通知
 
 ブラウザ通知は設定画面から明示的に有効化します。ページを開いただけでは通知権限を要求しません。

--- a/install-options.json
+++ b/install-options.json
@@ -1,0 +1,20 @@
+{
+  "apiVersion": "install.takosumi.com/v1alpha1",
+  "kind": "CapsuleSourceOptions",
+  "metadata": {
+    "name": "yurucommu",
+    "title": "Yurucommu",
+    "description": "Choose a deployment target for Yurucommu."
+  },
+  "options": [
+    {
+      "id": "cloudflare",
+      "title": "Cloudflare",
+      "description": "Deploy the Cloudflare OpenTofu module.",
+      "source": {
+        "url": "https://github.com/tako0614/yurucommu.git",
+        "path": "."
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- publish the optional root CapsuleSourceOptions document
- offer only the real root Cloudflare OpenTofu module
- document that direct Git installs remain valid and that other clouds require real modules
- leave ref omitted so the external-link resolver selects the highest stable SemVer tag once the next ordinary tag contains the document

## Boundary

The document is presentation-only. It contains no credentials, provider configuration, pricing, capacity, interfaces, dependencies, or install policy.

## Validation

- closed JSON/source/tag/module validation
- tofu fmt -check -recursive
- tofu init -backend=false -lockfile=readonly
- tofu validate
- bun run check
- bun run test
- bun run fmt:check
- bun run build
- bunx prettier --check README.md install-options.json
