### PR TITLE
chore(release): prepare v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.1.1 - 2026-07-19
+
+- Publish the optional Capsule Source Options chooser for the existing
+  Cloudflare OpenTofu module.
+
 ## 2.1.0 - 2026-07-16
 
 - Add browser notification push registration and delivery support from `@takosjp/yurucommu-core` 3.1.

--- a/main.tf
+++ b/main.tf
@@ -195,7 +195,7 @@ variable "worker_bundle_path" {
 variable "worker_release_tag" {
   description = "GitHub release tag whose takosumi-artifact.json selects the default Worker bundle and SHA-256. Set empty to use worker_bundle_path."
   type        = string
-  default     = "v2.1.0"
+  default     = "v2.1.1"
 
   validation {
     condition     = trimspace(var.worker_release_tag) == "" || can(regex("^v[0-9]+\\.[0-9]+\\.[0-9]+([-+][0-9A-Za-z.-]+)?$", trimspace(var.worker_release_tag)))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@takosjp/yurucommu",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "AGPL-3.0-only",
   "type": "module",
   "private": true,


### PR DESCRIPTION
Prepare the Capsule Source Options stable patch release.

- bump package and default Worker release tag
- add changelog entry

Local checks, tests, lint, formatting, builds, and OpenTofu validation pass.