### PR TITLE
Record Yurucommu v2.1.5 release provenance

### DIFF
--- a/release.lock.json
+++ b/release.lock.json
@@ -53,6 +53,19 @@
       },
       "commit": "90b0da9a075ba19f54927ce4c8e216c0da89ad49",
       "seededFrom": "owner deploy exact release readback on 2026-08-03"
+    },
+    "v2.1.5": {
+      "artifact": {
+        "filename": "yurucommu-worker.js",
+        "url": "https://github.com/tako0614/yurucommu/releases/download/v2.1.5/yurucommu-worker.js",
+        "sha256": "sha256:6e39a18ea95172affd2d4b12d24f2e59ab9f5f1af7a14a80ec3989275bed66bd"
+      },
+      "manifest": {
+        "url": "https://github.com/tako0614/yurucommu/releases/download/v2.1.5/takosumi-artifact.json",
+        "sha256": "sha256:b4d5747561311469ab9dcc256f46f9f32005e3bec5d603768bc33617b2379def"
+      },
+      "commit": "3a62adf2767824159935de3fff6331b5d222ed8b",
+      "seededFrom": "read-only GitHub tag, Release API, and downloaded asset readback on 2026-08-14; reconciled against manifest identity, source commit, URLs, Worker digest, manifest digest, and checksum"
     }
   }
 }


### PR DESCRIPTION
## Summary
- append the canonical historical `v2.1.5` entry to `release.lock.json`
- record the independently read-back tag commit, Worker asset digest, and manifest digest
- preserve existing release ordering and lock schema; no product/version/deploy changes

## Evidence
- base: `main` at `ea0811463dcab783be3061aa9d3a2918ce17a20c`
- head: `repair/yuru-v215-release-lock` at `a3b7f2063bdd8659a676b8855ba470c196d209b9`
- tree: one tracked file changed, `release.lock.json` (+13)
- tag: `v2.1.5` -> `3a62adf2767824159935de3fff6331b5d222ed8b`
- Worker SHA-256: `6e39a18ea95172affd2d4b12d24f2e59ab9f5f1af7a14a80ec3989275bed66bd`
- manifest SHA-256: `b4d5747561311469ab9dcc256f46f9f32005e3bec5d603768bc33617b2379def`

## Checks
- `bun test scripts/release-version.test.ts scripts/takosumi-release.test.ts` (15 passed)
- `bunx prettier --check release.lock.json`
- `git diff --check`
- `bun run check` (171 tests passed; OpenTofu, build, and release-worker smoke passed)
