### PR TITLE
chore(release): prepare Yurucommu v2.1.6 Takoform transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.1.6 - Unreleased
+
+- Pin the Takoform adapter to provider `1.0.4` and request the explicit
+  RelationalDatabase v2-to-v3 Form transition for existing installations.
+- Keep EdgeWorker updates on the recorded Form3 identity while advancing the
+  immutable Worker release reference.
+
 ## 2.1.1 - 2026-07-19
 
 - Publish the optional Capsule Source Options chooser for the existing

--- a/deploy/takoform/.terraform.lock.hcl
+++ b/deploy/takoform/.terraform.lock.hcl
@@ -2,19 +2,19 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.opentofu.org/tako0614/takoform" {
-  version     = "1.0.3"
-  constraints = "1.0.3"
+  version     = "1.0.4"
+  constraints = "1.0.4"
   hashes = [
-    "h1:+98nPh6Rf6DkibzbBAeY1+u9OObxLjPjom6lhj88ELo=",
-    "h1:1OfcRIKMbTY8fxWOvbY57DP7U1yZzWlctvoN/PNhQk8=",
-    "h1:kd8kRxJF9g1a9lBULJl4yBGixp/Yme+9Jgr6tU5I8gw=",
-    "h1:tHD1RyH/tOz0HE5sMXCKKX4PwHfyGaEpEyUj04OMprU=",
-    "h1:tseFH2/xjTN5il7tL6kGtu3dzb4nixF1t7IZp4ELLXs=",
-    "zh:1d3c63a1b15dcb7ebd898a23c9e1ee908f7e9297b4ab78898fa06bdf65f9d3c6",
-    "zh:33dd129ab6eba593c60266e08142c900d4a74be9138ce09e57ba62d2227c98f9",
-    "zh:3f0f729b68472aa6cd01b1f7f9e3d1c93a31b3f513c5a18f0ca755b93c2bda68",
-    "zh:b235f4e0915d7c5d56fdf3477f1676d6669ae5e20dbf2b810de1a28bab27d28c",
+    "h1:QemqcYsnonxBBKf2UwucT2dXx1RuwyO0aBVcf05Vm5k=",
+    "h1:ZO1MBhSXtyy1NtksOR//E6jN4/7TSjV/QyC9Sopn+hM=",
+    "h1:acWNfLQI+pFTcHKxvGMyJQVy7tBm+HDXWR7zGqT+uV8=",
+    "h1:iFQ1WiCP4JLU0JFs4dZef3RyGBv4SIe1F1dwzoRR8ug=",
+    "h1:yc/TlsG01HmSlFt4SDFkpL6WMUgqB8s4LOXBiDZQrQE=",
+    "zh:0ee1efcbf69b693bf272a44d37a012761100b979576994a9dec9c24fc2ffa043",
+    "zh:3ae82f26ae7eb736f8f134c02f8c04a3fe0e5abdea5aa29211b47291f44fe61c",
+    "zh:3f38bf3f70ef592c99f694c912aac927ce91cf7005c80cdaf142db1ed80c71c9",
+    "zh:453a19095c7559e48708361141483e0e7d72c19e5deb14f009264220eb280155",
+    "zh:ab74a1bf709e823874168d0d83d8af3ca1f9779c175531054f639245b0c41915",
     "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
-    "zh:fb030cef69e05658bca35703656150c06f01f73c79cf14eb0a46f7413f405110",
   ]
 }

--- a/deploy/takoform/README.md
+++ b/deploy/takoform/README.md
@@ -69,6 +69,24 @@ The module pins three values together:
 An update must change all three to the same release. This prevents an
 installation from downloading different bytes under an unchanged definition.
 
+### Existing provider-v1 Form transition
+
+The v2.1.6 adapter pins Takoform provider `1.0.4`. For an existing
+RelationalDatabase recorded as Form2, the module sets the provider-only marker
+`form_transition = "relational-database-v2-to-v3"` together with the immutable
+schema bundle. The provider performs the host's exact transition protocol and
+keeps the old Form identity in state until the host returns committed proof for
+the same Resource, request, revision, and native identity. This is a
+same-resource database/data migration: retain the backend state backup and
+recovery evidence before Apply, and do not retry an indeterminate operation by
+editing state.
+
+The marker is accepted only on `takoform_relational_database.database`; it is
+not a generic resource switch and must not be copied to the EdgeWorker or other
+resources. An existing EdgeWorker recorded as Form3 receives an ordinary
+artifact update and remains Form3. EdgeWorker Form4-only fields are not added
+to this module. Fresh resources use the provider's current Forms.
+
 [`migrations/schema-bundle.json`](migrations/schema-bundle.json) is one
 self-contained immutable database artifact. It is generated from the exact
 installed and locked `@takosjp/yurucommu-core` migration files, with each SQL

--- a/deploy/takoform/main.tf
+++ b/deploy/takoform/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     takoform = {
       source  = "registry.opentofu.org/tako0614/takoform"
-      version = "= 1.0.3"
+      version = "= 1.0.4"
     }
   }
 }
@@ -23,7 +23,7 @@ variable "project_name" {
 variable "worker_release_tag" {
   description = "Yurucommu GitHub release containing takosumi-artifact.json."
   type        = string
-  default     = "v2.1.5"
+  default     = "v2.1.6"
 
   validation {
     condition     = trimspace(var.worker_release_tag) == "" || can(regex("^v[0-9]+\\.[0-9]+\\.[0-9]+([-+][0-9A-Za-z.-]+)?$", trimspace(var.worker_release_tag)))
@@ -34,7 +34,7 @@ variable "worker_release_tag" {
 variable "worker_bundle_url" {
   description = "Immutable HTTPS Worker artifact URL pinned by this Yurucommu release."
   type        = string
-  default     = "https://github.com/tako0614/yurucommu/releases/download/v2.1.5/yurucommu-worker.js"
+  default     = "https://github.com/tako0614/yurucommu/releases/download/v2.1.6/yurucommu-worker.js"
 
   validation {
     condition     = can(regex("^https://[^[:space:]]+$", trimspace(var.worker_bundle_url)))
@@ -62,11 +62,12 @@ locals {
 }
 
 resource "takoform_relational_database" "database" {
-  name          = "${local.prefix}-db"
-  engine        = "sqlite"
-  schema_url    = "https://raw.githubusercontent.com/tako0614/yurucommu/bf7a3bdb55d9bd562ac895ada10ac42ce09a11b9/deploy/takoform/migrations/schema-bundle.json"
-  schema_sha256 = "f14135367b4b00a520f0ef8abc41f67d53c6abb9ef8577d946fb199987f5abaa"
-  schema_format = "takosumi.resource-migrations"
+  name            = "${local.prefix}-db"
+  engine          = "sqlite"
+  schema_url      = "https://raw.githubusercontent.com/tako0614/yurucommu/bf7a3bdb55d9bd562ac895ada10ac42ce09a11b9/deploy/takoform/migrations/schema-bundle.json"
+  schema_sha256   = "f14135367b4b00a520f0ef8abc41f67d53c6abb9ef8577d946fb199987f5abaa"
+  schema_format   = "takosumi.resource-migrations"
+  form_transition = "relational-database-v2-to-v3"
 }
 
 resource "takoform_object_bucket" "media" {

--- a/install-options.json
+++ b/install-options.json
@@ -13,7 +13,7 @@
       "description": "Run Yurucommu on cloud resources provided by Takosumi Cloud.",
       "source": {
         "url": "https://github.com/tako0614/yurucommu.git",
-        "ref": "v2.1.5",
+        "ref": "v2.1.6",
         "path": "deploy/takoform"
       }
     },
@@ -23,7 +23,7 @@
       "description": "Advanced: run Yurucommu in your own Cloudflare account.",
       "source": {
         "url": "https://github.com/tako0614/yurucommu.git",
-        "ref": "v2.1.5",
+        "ref": "v2.1.6",
         "path": "."
       }
     }

--- a/main.tf
+++ b/main.tf
@@ -223,7 +223,7 @@ variable "worker_bundle_path" {
 variable "worker_release_tag" {
   description = "Immutable GitHub release identity for the Worker artifact. With no explicit worker_bundle_url it selects the append-only release.lock.json entry; with an explicit URL the URL must select this exact tag. Set both empty to use worker_bundle_path."
   type        = string
-  default     = "v2.1.5"
+  default     = "v2.1.6"
 
   validation {
     condition     = trimspace(var.worker_release_tag) == "" || can(regex("^v[0-9]+\\.[0-9]+\\.[0-9]+([-+][0-9A-Za-z.-]+)?$", trimspace(var.worker_release_tag)))
@@ -234,7 +234,7 @@ variable "worker_release_tag" {
 variable "worker_bundle_url" {
   description = "Optional HTTPS URL for a prebuilt Worker module JS artifact. When set, OpenTofu downloads this artifact and verifies worker_bundle_sha256 before upload."
   type        = string
-  default     = "https://github.com/tako0614/yurucommu/releases/download/v2.1.5/yurucommu-worker.js"
+  default     = "https://github.com/tako0614/yurucommu/releases/download/v2.1.6/yurucommu-worker.js"
 
   validation {
     condition     = trimspace(var.worker_bundle_url) == "" || can(regex("^https://[^[:space:]]+$", trimspace(var.worker_bundle_url)))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@takosjp/yurucommu",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "license": "AGPL-3.0-only",
   "type": "module",
   "private": true,

--- a/scripts/takoform-capsule.test.ts
+++ b/scripts/takoform-capsule.test.ts
@@ -24,6 +24,12 @@ const edgeWorkerConnectionNames = edgeWorkerConnectionsText
       (match) => match[1],
     )
   : [];
+const databaseResourceText = main.match(
+  /resource "takoform_relational_database" "database" \{([\s\S]*?)\n\}\n\nresource "takoform_object_bucket"/,
+)?.[1];
+const edgeWorkerResourceText = main.match(
+  /resource "takoform_edge_worker" "worker" \{([\s\S]*?)\n\}\n\nresource "takoform_schedule"/,
+)?.[1];
 
 describe("portable Takoform Capsule", () => {
   test("owns the complete Yurucommu portable resource graph", () => {
@@ -89,14 +95,23 @@ describe("portable Takoform Capsule", () => {
   });
 
   test("declares the immutable schema bundle on the database resource", () => {
-    expect(main).toContain('version = "= 1.0.3"');
+    expect(main).toContain('version = "= 1.0.4"');
     expect(main).toContain(
-      'schema_url    = "https://raw.githubusercontent.com/tako0614/yurucommu/bf7a3bdb55d9bd562ac895ada10ac42ce09a11b9/deploy/takoform/migrations/schema-bundle.json"',
+      'schema_url      = "https://raw.githubusercontent.com/tako0614/yurucommu/bf7a3bdb55d9bd562ac895ada10ac42ce09a11b9/deploy/takoform/migrations/schema-bundle.json"',
     );
     expect(main).toContain(
-      'schema_sha256 = "f14135367b4b00a520f0ef8abc41f67d53c6abb9ef8577d946fb199987f5abaa"',
+      'schema_sha256   = "f14135367b4b00a520f0ef8abc41f67d53c6abb9ef8577d946fb199987f5abaa"',
     );
-    expect(main).toContain('schema_format = "takosumi.resource-migrations"');
+    expect(main).toContain('schema_format   = "takosumi.resource-migrations"');
+    expect(main).toContain('form_transition = "relational-database-v2-to-v3"');
+    expect(main.match(/form_transition\s*=\s*"[^"]+"/g) ?? []).toHaveLength(1);
+    expect(databaseResourceText).toContain(
+      'form_transition = "relational-database-v2-to-v3"',
+    );
+    expect(edgeWorkerResourceText).toBeDefined();
+    expect(edgeWorkerResourceText).not.toContain("form_transition");
+    expect(edgeWorkerResourceText).not.toContain("assets_path");
+    expect(edgeWorkerResourceText).not.toContain("assets_not_found_handling");
     expect(main).not.toContain("resource_migration");
     expect(main).not.toContain("manifest.json");
   });

--- a/scripts/takosumi-install-ux.test.ts
+++ b/scripts/takosumi-install-ux.test.ts
@@ -247,7 +247,7 @@ describe("repository-owned Takosumi install UX", () => {
         id: "takosumi-cloud",
         source: {
           url: "https://github.com/tako0614/yurucommu.git",
-          ref: "v2.1.5",
+          ref: "v2.1.6",
           path: "deploy/takoform",
         },
       },
@@ -255,7 +255,7 @@ describe("repository-owned Takosumi install UX", () => {
         id: "cloudflare",
         source: {
           url: "https://github.com/tako0614/yurucommu.git",
-          ref: "v2.1.5",
+          ref: "v2.1.6",
           path: ".",
         },
       },


### PR DESCRIPTION
## Summary

- prepare the Yurucommu v2.1.6 candidate across package, install, root, and Takoform references
- pin Takoform provider 1.0.4 and refresh only the portable module lockfile
- request the explicit RelationalDatabase v2-to-v3 transition while keeping the EdgeWorker on Form3
- keep the existing schema URL/digest and deterministic Worker artifact digest unchanged

## Verification

- `bun test scripts/takoform-capsule.test.ts scripts/takosumi-install-ux.test.ts scripts/release-version.test.ts scripts/release-worker-smoke.test.ts`
- `bun run check`
- `bun run build:worker` -> `sha256:6e39a18ea95172affd2d4b12d24f2e59ab9f5f1af7a14a80ec3989275bed66bd`
- Takoform provider 1.0.4 binary -> `sha256:e56cf8fcd5741168a5e156782d5a91d6431daa24a7f02045e56357de729df48b`

Release publication/tagging is intentionally not included; `release.lock.json` retains only the published v2.1.5 identity.