### PR TITLE
fix(release): require immutable GitHub releases

### DIFF
--- a/scripts/deploy.mjs
+++ b/scripts/deploy.mjs
@@ -95,13 +95,13 @@ const CONTRACT = {
         provenance:
           "refuses a dirty, detached, or unpushed worktree; requires main for publication; runs `bun run check`; builds and boots the embedded Worker from that exact commit; requires Store sources and module defaults to select its tag, URL, and SHA-256; and records the source commit plus SHA-256 in the release manifest",
         "post-conditions":
-          "reads the create-only tag and GitHub Release back, requires the tag to resolve to the source commit, downloads all three assets, requires their exact SHA-256 digests, and boots the downloaded Worker in workerd with the Takosumi managed-runtime materialization",
+          "reads the create-only tag and GitHub Release back, requires the tag to resolve to the source commit and the Release to report isImmutable:true, downloads all three assets, requires their exact SHA-256 digests, and boots the downloaded Worker in workerd with the Takosumi managed-runtime materialization",
         reversal:
           "the release identity is never replaced or deleted by this entrypoint; consumers remain able to pin the preceding release, and a defect is repaired by publishing a higher version",
         "failure-handling":
           "fails before mutation when the tag or release already exists; after release creation starts it reports an indeterminate publication and requires authoritative tag/release readback before any retry",
         "no-overwrite":
-          "derives one SemVer tag from package.json, refuses any existing local/remote tag or GitHub Release, and uses GitHub create-only release publication without update or delete paths",
+          "derives one SemVer tag from package.json, refuses any existing local/remote tag or GitHub Release, reads repos/tako0614/yurucommu/immutable-releases immediately before create and requires enabled:true, requires post-readback isImmutable:true, and uses GitHub create-only release publication without update or delete paths",
       },
     },
   ],
@@ -269,6 +269,36 @@ function requireCleanPushedSource(execute) {
   return { branch, commit };
 }
 
+function requireRepositoryImmutableReleases() {
+  const endpoint = `repos/${R.repository}/immutable-releases`;
+  let body;
+  try {
+    body = run("gh", ["api", endpoint]);
+  } catch (error) {
+    const detail = `${error.stdout ?? ""}${error.stderr ?? ""}`.trim();
+    die(
+      `cannot read ${endpoint} immediately before release creation; refusing to publish without authoritative immutable-release settings`,
+      detail ? detail.split("\n").slice(0, 20) : [],
+    );
+  }
+
+  let settings;
+  try {
+    settings = JSON.parse(body);
+  } catch (error) {
+    die(
+      `${endpoint} returned invalid JSON; refusing to publish without authoritative immutable-release settings`,
+      [String(error.message)],
+    );
+  }
+  if (settings?.enabled !== true) {
+    die(
+      `${endpoint} is not enabled (enabled=${String(settings?.enabled)}); refusing to create a mutable Release`,
+    );
+  }
+  process.stdout.write(`${endpoint} enabled:true\n`);
+}
+
 function publishWorkerRelease() {
   if (
     process.argv.includes("--execute") &&
@@ -369,6 +399,7 @@ function publishWorkerRelease() {
   }
 
   process.stdout.write(`\n==> create-only GitHub Release ${tag}\n`);
+  requireRepositoryImmutableReleases();
   try {
     const output = run("gh", [
       "release",
@@ -415,11 +446,18 @@ function publishWorkerRelease() {
       "--repo",
       R.repository,
       "--json",
-      "isDraft,isPrerelease,tagName,url,assets",
+      "isDraft,isPrerelease,isImmutable,tagName,url,assets",
     ]),
   );
-  if (release.isDraft || release.isPrerelease || release.tagName !== tag) {
-    die(`published Release ${tag} has unexpected state`);
+  if (
+    release.isDraft ||
+    release.isPrerelease ||
+    release.isImmutable !== true ||
+    release.tagName !== tag
+  ) {
+    die(
+      `published Release ${tag} has unexpected state (isImmutable=${String(release.isImmutable)})`,
+    );
   }
   const remoteAssets = new Map(
     release.assets.map((asset) => [asset.name, asset.digest]),

--- a/scripts/release-version.test.ts
+++ b/scripts/release-version.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, test } from "bun:test";
-import { readFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import {
+  chmod,
+  mkdtemp,
+  mkdir,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { join } from "node:path";
 
 const [
   packageSource,
@@ -48,6 +57,192 @@ function deploymentDefault(
       new RegExp(`variable\\s+"${variable}"\\s*\\{([\\s\\S]*?)\\n\\}`, "u"),
     )?.[1]
     ?.match(/default\s+=\s+"([^"]*)"/u)?.[1];
+}
+
+const fakeCommit = "1111111111111111111111111111111111111111";
+
+function sha256(value: string | Uint8Array): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+type ReleaseScenario = {
+  immutableSettings: string;
+  readback: string;
+  createFails?: boolean;
+};
+
+async function createReleaseHarness(scenario: ReleaseScenario) {
+  const root = await mkdtemp(join(process.cwd(), ".yurucommu-release-guard-"));
+  const fakeBin = join(root, "bin");
+  const scripts = join(root, "scripts");
+  const takoform = join(root, "deploy", "takoform");
+  const dist = join(root, "dist");
+  const temp = join(root, "tmp");
+  await mkdir(fakeBin, { recursive: true });
+  await mkdir(scripts, { recursive: true });
+  await mkdir(takoform, { recursive: true });
+  await mkdir(dist, { recursive: true });
+  await mkdir(temp, { recursive: true });
+
+  const artifact = Buffer.from("test release worker artifact\n");
+  const artifactDigest = sha256(artifact);
+  const tag = `v${packageVersion}`;
+  const artifactUrl = `https://github.com/tako0614/yurucommu/releases/download/${tag}/yurucommu-worker.js`;
+  const manifestUrl = `https://github.com/tako0614/yurucommu/releases/download/${tag}/takosumi-artifact.json`;
+  const manifest = {
+    kind: "takosumi.worker-artifact@v1",
+    app: "yurucommu",
+    commit: fakeCommit,
+    ref: tag,
+    releaseTag: tag,
+    artifact: {
+      filename: "yurucommu-worker.js",
+      url: artifactUrl,
+      sha256: artifactDigest,
+      sha256Prefixed: `sha256:${artifactDigest}`,
+      contentType: "application/javascript",
+    },
+    manifestUrl,
+  };
+  const manifestText = `${JSON.stringify(manifest, null, 2)}\n`;
+  const checksumText = `${artifactDigest}  yurucommu-worker.js\n`;
+  const artifactPath = join(dist, "yurucommu-worker.js");
+  const manifestPath = join(root, "takosumi-artifact.json");
+  const checksumPath = join(root, "yurucommu-worker.js.sha256");
+  const ghLogPath = join(root, "gh.log");
+  const tagStatePath = join(root, "tag-created");
+
+  const [deploySource, packageText, installText, rootModule, takoformModule] =
+    await Promise.all([
+      readFile(new URL("./deploy.mjs", import.meta.url), "utf8"),
+      readFile(new URL("../package.json", import.meta.url), "utf8"),
+      readFile(new URL("../install-options.json", import.meta.url), "utf8"),
+      readFile(new URL("../main.tf", import.meta.url), "utf8"),
+      readFile(new URL("../deploy/takoform/main.tf", import.meta.url), "utf8"),
+    ]);
+  const replaceDigest = (source: string) =>
+    source.replace(
+      /(variable\s+"worker_bundle_sha256"[\s\S]*?default\s+=\s+")sha256:[^"]+/u,
+      `$1sha256:${artifactDigest}`,
+    );
+  await Promise.all([
+    writeFile(join(scripts, "deploy.mjs"), deploySource),
+    writeFile(join(root, "package.json"), packageText),
+    writeFile(join(root, "install-options.json"), installText),
+    writeFile(join(root, "main.tf"), replaceDigest(rootModule)),
+    writeFile(join(takoform, "main.tf"), replaceDigest(takoformModule)),
+    writeFile(artifactPath, artifact),
+    writeFile(manifestPath, manifestText),
+    writeFile(checksumPath, checksumText),
+    writeFile(ghLogPath, ""),
+    writeFile(tagStatePath, ""),
+  ]);
+
+  await writeFile(
+    join(fakeBin, "git"),
+    `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "$FAKE_GIT_LOG"
+case "$*" in
+  "status --porcelain") exit 0 ;;
+  "rev-parse --abbrev-ref HEAD") printf 'main\\n' ;;
+  "rev-parse --abbrev-ref --symbolic-full-name @{upstream}") printf 'origin/main\\n' ;;
+  "rev-parse HEAD"|"rev-parse origin/main") printf '%s\\n' '${fakeCommit}' ;;
+  "tag --list"*) exit 0 ;;
+  "ls-remote --tags"*)
+    if [ -s "$FAKE_TAG_STATE" ]; then printf '%s\\trefs/tags/v2.1.6\\n' '${fakeCommit}'; fi
+    exit 0
+    ;;
+  "fetch"*) exit 0 ;;
+  *) exit 0 ;;
+esac
+`,
+  );
+  await writeFile(
+    join(fakeBin, "bun"),
+    `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "$FAKE_BUN_LOG"
+exit 0
+`,
+  );
+  await writeFile(
+    join(fakeBin, "gh"),
+    `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "$FAKE_GH_LOG"
+if [ "$1" = "api" ] && [ "$2" = "repos/tako0614/yurucommu/immutable-releases" ]; then
+  printf '%s' "$FAKE_GH_IMMUTABLE_SETTINGS"
+  exit 0
+fi
+if [ "$1" = "release" ] && [ "$2" = "view" ]; then
+  case " $* " in
+    *" --json "*) printf '%s' "$FAKE_GH_READBACK"; exit 0 ;;
+    *) printf '%s\\n' 'release not found' >&2; exit 1 ;;
+  esac
+fi
+if [ "$1" = "release" ] && [ "$2" = "create" ]; then
+  if [ "\${FAKE_GH_CREATE_FAIL:-0}" = "1" ]; then
+    printf '%s\\n' 'simulated release create lost acknowledgement' >&2
+    exit 1
+  fi
+  printf '%s\\n' 'created'
+  printf '%s' 'created' > "$FAKE_TAG_STATE"
+  exit 0
+fi
+if [ "$1" = "release" ] && [ "$2" = "download" ]; then
+  directory=""
+  previous=""
+  for argument in "$@"; do
+    if [ "$previous" = "--dir" ]; then directory="$argument"; fi
+    previous="$argument"
+  done
+  mkdir -p "$directory"
+  cp "$FAKE_ARTIFACT_PATH" "$directory/yurucommu-worker.js"
+  cp "$FAKE_MANIFEST_PATH" "$directory/takosumi-artifact.json"
+  cp "$FAKE_CHECKSUM_PATH" "$directory/yurucommu-worker.js.sha256"
+  exit 0
+fi
+printf '%s\\n' "unexpected gh command: $*" >&2
+exit 1
+`,
+  );
+  await Promise.all(
+    ["git", "bun", "gh"].map((name) => chmod(join(fakeBin, name), 0o755)),
+  );
+
+  const environment = {
+    ...process.env,
+    PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+    TMPDIR: temp,
+    FAKE_GIT_LOG: ghLogPath,
+    FAKE_BUN_LOG: ghLogPath,
+    FAKE_GH_LOG: ghLogPath,
+    FAKE_GH_IMMUTABLE_SETTINGS: scenario.immutableSettings,
+    FAKE_GH_READBACK: scenario.readback,
+    FAKE_GH_CREATE_FAIL: scenario.createFails ? "1" : "0",
+    FAKE_TAG_STATE: tagStatePath,
+    FAKE_ARTIFACT_PATH: artifactPath,
+    FAKE_MANIFEST_PATH: manifestPath,
+    FAKE_CHECKSUM_PATH: checksumPath,
+  };
+  const result = Bun.spawnSync(
+    [
+      process.execPath,
+      join(scripts, "deploy.mjs"),
+      "yurucommu-worker-release",
+      "--execute",
+    ],
+    { cwd: root, env: environment, stdout: "pipe", stderr: "pipe" },
+  );
+  const output = {
+    exitCode: result.exitCode,
+    stdout: result.stdout.toString(),
+    stderr: result.stderr.toString(),
+    ghLog: await readFile(ghLogPath, "utf8"),
+  };
+  await rm(root, { recursive: true, force: true });
+  return output;
 }
 
 describe("release version", () => {
@@ -132,6 +327,14 @@ describe("release surface status", () => {
     expect(release?.obligations["post-conditions"]).toContain(
       "Takosumi managed-runtime",
     );
+    expect(release?.obligations["post-conditions"]).toContain(
+      "isImmutable:true",
+    );
+    expect(release?.obligations["no-overwrite"]).toContain(
+      "immutable-releases",
+    );
+    expect(release?.obligations["no-overwrite"]).toContain("enabled:true");
+    expect(release?.obligations["no-overwrite"]).toContain("isImmutable:true");
   });
 
   test("does not expose legacy release or deployment aliases", () => {
@@ -162,5 +365,119 @@ describe("release surface status", () => {
   test("does not advertise a selectable Takosumi Cloud install before its gates pass", () => {
     expect(siteSource).not.toContain("app.takosumi.com/install");
     expect(siteSource).toContain("Takosumi Cloud での追加は準備中");
+  });
+});
+
+function readbackPayload(isImmutable: boolean | undefined): string {
+  const artifact = Buffer.from("test release worker artifact\n");
+  const artifactDigest = sha256(artifact);
+  const tag = `v${packageVersion}`;
+  const artifactUrl = `https://github.com/tako0614/yurucommu/releases/download/${tag}/yurucommu-worker.js`;
+  const manifestUrl = `https://github.com/tako0614/yurucommu/releases/download/${tag}/takosumi-artifact.json`;
+  const manifest = {
+    kind: "takosumi.worker-artifact@v1",
+    app: "yurucommu",
+    commit: fakeCommit,
+    ref: tag,
+    releaseTag: tag,
+    artifact: {
+      filename: "yurucommu-worker.js",
+      url: artifactUrl,
+      sha256: artifactDigest,
+      sha256Prefixed: `sha256:${artifactDigest}`,
+      contentType: "application/javascript",
+    },
+    manifestUrl,
+  };
+  const manifestText = `${JSON.stringify(manifest, null, 2)}\n`;
+  const checksumText = `${artifactDigest}  yurucommu-worker.js\n`;
+  const payload: Record<string, unknown> = {
+    isDraft: false,
+    isPrerelease: false,
+    isImmutable,
+    tagName: tag,
+    url: `https://github.com/tako0614/yurucommu/releases/tag/${tag}`,
+    assets: [
+      { name: "yurucommu-worker.js", digest: `sha256:${artifactDigest}` },
+      {
+        name: "takosumi-artifact.json",
+        digest: `sha256:${sha256(manifestText)}`,
+      },
+      {
+        name: "yurucommu-worker.js.sha256",
+        digest: `sha256:${sha256(checksumText)}`,
+      },
+    ],
+  };
+  if (isImmutable === undefined) delete payload.isImmutable;
+  return JSON.stringify(payload);
+}
+
+describe("immutable GitHub release guard", () => {
+  test("does not call release create when the repository setting is disabled", async () => {
+    const result = await createReleaseHarness({
+      immutableSettings: JSON.stringify({ enabled: false }),
+      readback: readbackPayload(true),
+    });
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.ghLog).not.toContain("release create");
+    expect(result.stderr).toContain("immutable");
+  });
+
+  test.each([
+    ["false", readbackPayload(false)],
+    ["missing", readbackPayload(undefined)],
+  ])(
+    "rejects a post-create Release whose isImmutable is %s without emitting PUBLISHED",
+    async (_label, readback) => {
+      const result = await createReleaseHarness({
+        immutableSettings: JSON.stringify({ enabled: true }),
+        readback,
+      });
+
+      expect(result.exitCode).not.toBe(0);
+      expect(result.ghLog).toContain("release create");
+      expect(result.stdout).not.toContain('"status": "PUBLISHED"');
+      expect(result.stderr).toContain("isImmutable");
+    },
+  );
+
+  test("reads the enabled setting immediately before create and preserves immutable create-only publication", async () => {
+    const result = await createReleaseHarness({
+      immutableSettings: JSON.stringify({ enabled: true }),
+      readback: readbackPayload(true),
+    });
+
+    const commands = result.ghLog.trim().split("\n");
+    const settingRead = commands.findIndex(
+      (command) =>
+        command === "api repos/tako0614/yurucommu/immutable-releases",
+    );
+    const create = commands.findIndex((command) =>
+      command.startsWith("release create "),
+    );
+    expect(result.exitCode).toBe(0);
+    expect(settingRead).toBeGreaterThanOrEqual(0);
+    expect(create).toBe(settingRead + 1);
+    expect(result.stdout).toContain('"status": "PUBLISHED"');
+  });
+
+  test("retains lost-ack behavior when create fails after the setting read", async () => {
+    const result = await createReleaseHarness({
+      immutableSettings: JSON.stringify({ enabled: true }),
+      readback: readbackPayload(true),
+      createFails: true,
+    });
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.ghLog).toContain(
+      "api repos/tako0614/yurucommu/immutable-releases",
+    );
+    expect(result.ghLog).toContain("release create");
+    expect(result.stdout).not.toContain('"status": "PUBLISHED"');
+    expect(result.stderr).toContain(
+      "publication of v2.1.6 started but did not complete cleanly",
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Read the authoritative `repos/tako0614/yurucommu/immutable-releases` setting immediately before `gh release create` and fail closed unless `enabled:true`.
- Include `isImmutable` in the post-create Release readback and fail closed unless it is strictly `true`, before emitting `PUBLISHED`.
- Preserve create-only publication and lost-ack handling.
- Add release-harness coverage for disabled settings, false/missing post-readback, the successful immutable path, and lost acknowledgement.

## Verification

- `bun test scripts/release-version.test.ts`: 11 passed, 79 expects.
- `TMPDIR=../tmp bun install --frozen-lockfile`: Bun 1.3.14; 222 installs / 353 packages checked, no lockfile changes.
- `TMPDIR=../tmp bun run check` from a clean `dist/` with the repository-external task TMPDIR: 176 tests passed, 730 expects; OpenTofu validation passed with Takoform provider v1.0.4; release Worker smoke passed.
- Worker artifact digest from the full gate: `sha256:6e39a18ea95172affd2d4b12d24f2e59ab9f5f1af7a14a80ec3989275bed66bd` (2,731,079 bytes). Two subsequent clean-`dist` builds with the same external TMPDIR reproduced the exact digest.
- The earlier conflicting hashes were environment contamination: in-repository diagnostic/cache/generated files were visible to Tailwind's automatic source scan. No source or dependency drift was found; package.json and bun.lock hashes remained `e1654b9e660a9fb735b9dac14507667424a9c3f5edc98c6191b9e285e8eaa068` and `da3f77c0e47ecca9809a81018fa298c982c6e091794cb6105b4397bcb8ef71ff`.

No release, tag, repository-setting mutation, deployment, or apply was performed.