### PR TITLE
Record Yurucommu v2.1.6 release lock

### DIFF
--- a/release.lock.json
+++ b/release.lock.json
@@ -66,6 +66,19 @@
       },
       "commit": "3a62adf2767824159935de3fff6331b5d222ed8b",
       "seededFrom": "read-only GitHub tag, Release API, and downloaded asset readback on 2026-08-14; reconciled against manifest identity, source commit, URLs, Worker digest, manifest digest, and checksum"
+    },
+    "v2.1.6": {
+      "artifact": {
+        "filename": "yurucommu-worker.js",
+        "url": "https://github.com/tako0614/yurucommu/releases/download/v2.1.6/yurucommu-worker.js",
+        "sha256": "sha256:6e39a18ea95172affd2d4b12d24f2e59ab9f5f1af7a14a80ec3989275bed66bd"
+      },
+      "manifest": {
+        "url": "https://github.com/tako0614/yurucommu/releases/download/v2.1.6/takosumi-artifact.json",
+        "sha256": "sha256:d58a0f955ba75aadbc16622773e0ec4f4204b43397fd5a69523d13e389faa59f"
+      },
+      "commit": "ab0089c47827383c6ef2014def5bbef3be01bbc7",
+      "seededFrom": "owner deploy exact immutable GitHub Release/tag/downloaded asset readback on 2026-08-14"
     }
   }
 }


### PR DESCRIPTION
## Summary
- append exactly one `v2.1.6` entry to `release.lock.json`
- pin source/tag commit `ab0089c47827383c6ef2014def5bbef3be01bbc7` and the immutable GitHub Release assets
- leave all prior lock entries unchanged

## Publication readback
- Release ID: `370443575` (`immutable: true`)
- exactly three assets: Worker, manifest, checksum
- Worker: `sha256:6e39a18ea95172affd2d4b12d24f2e59ab9f5f1af7a14a80ec3989275bed66bd`
- manifest: `sha256:d58a0f955ba75aadbc16622773e0ec4f4204b43397fd5a69523d13e389faa59f`
- checksum asset: `sha256:6562108a501243a9d9a70976cc89ec24c19cc93ced5f3c4d5edb418c29962e89`

## Verification
- `bun test scripts/release-version.test.ts` (11 passed)
- `TMPDIR=/root/dev/takos/.tmp/yurucommu-v216-check bun run check` (fmt, tsc, OpenTofu, 176 tests/735 expectations, build, managed-runtime smoke passed)
- append-only/order and `git diff --check` passed

No deploy, tag, Release, or settings mutation was performed.